### PR TITLE
Using babel-loader for typescript files

### DIFF
--- a/configs/webpack/common.js
+++ b/configs/webpack/common.js
@@ -18,7 +18,7 @@ module.exports = {
       },
       {
         test: /\.tsx?$/,
-        use: 'awesome-typescript-loader',
+        use: ['babel-loader', 'awesome-typescript-loader'],
       },
       {
         test: /\.css$/,


### PR DESCRIPTION
Currently babel-loader is ineffective for typescript files so production build success from "target": "es5" setting in tsconfig.json not babel-loader.