### PR TITLE
Remove react-addons-test-utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "jest": "^24.1.0",
     "node-sass": "^4.11.0",
     "react": "^16.8.2",
-    "react-addons-test-utils": "^15.6.2",
     "react-dom": "^16.8.2",
     "react-hot-loader": "^4.7.0",
     "sass-loader": "^7.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6915,11 +6915,6 @@ rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-addons-test-utils@^15.6.2:
-  version "15.6.2"
-  resolved "https://registry.yarnpkg.com/react-addons-test-utils/-/react-addons-test-utils-15.6.2.tgz#c12b6efdc2247c10da7b8770d185080a7b047156"
-  integrity sha1-wStu/cIkfBDae4dw0YUICnsEcVY=
-
 react-dom@^16.8.2:
   version "16.8.2"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.8.2.tgz#7c8a69545dd554d45d66442230ba04a6a0a3c3d3"


### PR DESCRIPTION
`yarn check` fails because of react-addons-test-utils.

react-addons-test-utils is deprecated after react 15.5, and it seems that the functions are moved to react-dom.
See https://reactjs.org/docs/test-utils.html