### PR TITLE
Migrating React Hot Loader from v3 to v4

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { hot } from "react-hot-loader";
 import "./../assets/scss/App.scss";
 
 const reactLogo = require("./../assets/img/react_logo.svg");
@@ -6,7 +7,7 @@ const reactLogo = require("./../assets/img/react_logo.svg");
 export interface AppProps {
 }
 
-export default class App extends React.Component<AppProps, undefined> {
+class App extends React.Component<AppProps, undefined> {
     render() {
         return (
             <div className="app">
@@ -17,3 +18,7 @@ export default class App extends React.Component<AppProps, undefined> {
         );
     }
 }
+
+declare let module: Object;
+
+export default hot(module)(App);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,29 +1,10 @@
 import * as React from "react";
 import {render} from "react-dom";
-import {AppContainer} from "react-hot-loader";
 import App from "./components/App";
 
 const rootEl = document.getElementById("root");
 
 render(
-    <AppContainer>
-        <App/>
-    </AppContainer>,
+    <App/>,
     rootEl
 );
-
-// Hot Module Replacement API
-declare let module: { hot: any };
-
-if (module.hot) {
-    module.hot.accept("./components/App", () => {
-        const NewApp = require("./components/App").default;
-
-        render(
-            <AppContainer>
-                <NewApp/>
-            </AppContainer>,
-            rootEl
-        );
-    });
-}


### PR DESCRIPTION
As you can see in the [react-hot-loader](https://github.com/gaearon/react-hot-loader#migrating-from-v3) documentation, they recommend to use the *hot* helper instead of wrapping the application with `AppContainer` in the new version 4. 

I tested it and also the performance is increased :rocket: